### PR TITLE
Add quoting to the values of the data-id attributes used to identify elements.

### DIFF
--- a/jquery.quicksand.js
+++ b/jquery.quicksand.js
@@ -201,7 +201,7 @@ Github site: http://github.com/razorjack/quicksand
                         }
                     });
                 } else {
-                    destElement = $collection.filter('[' + options.attribute + '=' + $(this).attr(options.attribute) + ']');
+                    destElement = $collection.filter('[' + options.attribute + '="' + $(this).attr(options.attribute) + '"]');
                 }
                 if (destElement.length) {
                     // The item is both in source and destination collections
@@ -262,8 +262,8 @@ Github site: http://github.com/razorjack/quicksand
                         }
                     });
                 } else {
-                    sourceElement = $source.filter('[' + options.attribute + '=' + $(this).attr(options.attribute) + ']');
-                    destElement = $collection.filter('[' + options.attribute + '=' + $(this).attr(options.attribute) + ']');
+                    sourceElement = $source.filter('[' + options.attribute + '="' + $(this).attr(options.attribute) + '"]');
+                    destElement = $collection.filter('[' + options.attribute + '="' + $(this).attr(options.attribute) + '"]');
                 }
                 
                 var animationOptions;


### PR DESCRIPTION
Ran into a problem where we had some complex data-ids(UUIDs), that contain punctuation like '-'. This broke quicksand, because the element lookup filters didnt have quoting, and the expression would look like:
[data-id=435ce-3242e]
which would break jquery.

So, here's a really small pull request to add in quoting for data-id values :)  Makes it look like:
[data-id="435ce-3242e"]
