### PR TITLE
Add html5 canvas support

### DIFF
--- a/jquery.quicksand.js
+++ b/jquery.quicksand.js
@@ -17,6 +17,20 @@ Github site: http://github.com/razorjack/quicksand
  */
 
 (function($) {
+  
+  var cloneWithCanvases = function(jqueryObject) {
+      var clonedJqueryObject =  jqueryObject.clone();
+      var canvases = jqueryObject.find('canvas');
+      if (canvases.length) {
+          var clonedCanvases = clonedJqueryObject.find('canvas');
+          clonedCanvases.each(function(index) {
+              var context = this.getContext('2d');
+              context.drawImage(canvases.get(index), 0, 0);
+          });
+      }
+      return clonedJqueryObject;
+  };
+    
   $.fn.quicksand = function(collection, customOptions) {
     var options = {
       duration : 750,
@@ -57,7 +71,7 @@ Github site: http://github.com/razorjack/quicksand
       if (typeof(options.attribute) == 'function') {
         $collection = $(collection);
       } else {
-        $collection = $(collection).filter('[' + options.attribute + ']').clone(); // destination (target) collection
+        $collection = cloneWithCanvases($(collection).filter('[' + options.attribute + ']')); // destination (target) collection
       }
       var $sourceParent = $(this); // source, the visible container of source collection
       var sourceHeight = $(this).css('height'); // used to keep height and document flow during the animation
@@ -217,7 +231,7 @@ Github site: http://github.com/razorjack/quicksand
       });
 
       // create temporary container with destination collection
-      var $dest = $($sourceParent).clone();
+      var $dest = cloneWithCanvases($($sourceParent));
       var rawDest = $dest.get(0);
       rawDest.innerHTML = '';
       rawDest.setAttribute('id', '');
@@ -379,7 +393,7 @@ Github site: http://github.com/razorjack/quicksand
           }
 
           // Let's create it
-          var d = destElement.clone();
+          var d = cloneWithCanvases(destElement);
           var rawDestElement = d.get(0);
           rawDestElement.style.position = 'absolute';
           rawDestElement.style.margin = '0';


### PR DESCRIPTION
Native jQuery clone() method does not support canvas context copying. Therefore if source or destination collections contain canvases, all of them turn into blank rectangles during the quicksand animation.

This commit replaces all .clone() calls with a new function cloneWithCanvases() that fixes the described issue. The function causes a very small overhead, so the performance of the plugin is not affected.
