### PR TITLE
Fix for scale not reset to zero

### DIFF
--- a/jquery.quicksand.js
+++ b/jquery.quicksand.js
@@ -395,7 +395,7 @@ Github site: http://github.com/razorjack/quicksand
           d.css('opacity', 0.0); // IE
 
           if (options.useScaling) {
-            d.css('transform', 'scale(0.0)');
+            d.scale(0.0);
           }
           d.appendTo($sourceParent);
 


### PR DESCRIPTION
Hi Jack,

After updating to the latest (1.3), the scale would no longer animate in (from 0.0 to 1.0), although it would animate out just fine (from 1.0 to 0.0). This simple change seems to properly set the scale to zero so that it animates in. I have tested only on the Mac platform using Safari, Chrome, and Firefox. Hope it's helpful. Thanks for the cool jQuery plug-in.

-Steve
