### PR TITLE
Animation Fix for IE9

### DIFF
--- a/jquery.quicksand.js
+++ b/jquery.quicksand.js
@@ -71,7 +71,9 @@ Github site: http://github.com/razorjack/quicksand
       var width = $($source).innerWidth(); // need for the responsive design
 
       // Replace the collection and quit if IE6
-      if ($.browser.msie && parseInt($.browser.version, 10) < 7) {
+	  var ie6To8 = $.support.leadingWhitespace
+	  var ie7To8 = $.support.objectAll;
+	  if((ie6To8 && !ie7To8) || (!ie6To8 && ie7To8)) {
         $sourceParent.html('').append($collection);
         return;
       }


### PR DESCRIPTION
Due to User Agent Strings like: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0) - the current browser check actually matches IE9 as IE6 and, thus, the animation was not working in IE9. Performed a strong check based on using support and an XOR to determine whether the browser was IE6. This also solves the issue of $.browser not being support starting in jQuery 2.0.
